### PR TITLE
BK3738 - Create Job Endpoints

### DIFF
--- a/api/job.go
+++ b/api/job.go
@@ -87,16 +87,20 @@ func (server *Server) listJobs(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, jobs)
 }
 
-type UpdateJobRequest struct {
-	JobID     int64         `uri:"id" binding:"required,min=1"`
+type UpdateJobRequestUri struct {
+	JobID int64 `uri:"id" binding:"required,min=1"`
+}
+
+type UpdateJobRequestJson struct {
 	JobTitle  string        `form:"job_title" json:"job_title" binding:"required"`
 	MinSalary sql.NullInt64 `form:"min_salary" json:"min_salary" binding:"required"`
 	MaxSalary sql.NullInt64 `from:"max_salary" json:"max_salary" binding:"required"`
 }
 
 func (server *Server) updateJob(ctx *gin.Context) {
-	var req UpdateJobRequest
-	if errInUri := ctx.ShouldBindUri(&req); errInUri != nil {
+	var uri UpdateJobRequestUri
+	var req UpdateJobRequestJson
+	if errInUri := ctx.ShouldBindUri(&uri); errInUri != nil {
 		ctx.JSON(http.StatusBadRequest, errorResponse(errInUri))
 		return
 	}
@@ -107,7 +111,7 @@ func (server *Server) updateJob(ctx *gin.Context) {
 	}
 
 	arg := db.UpdateJobParams{
-		JobID:     req.JobID,
+		JobID:     uri.JobID,
 		JobTitle:  req.JobTitle,
 		MinSalary: req.MinSalary,
 		MaxSalary: req.MaxSalary,

--- a/api/job.go
+++ b/api/job.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"database/sql"
+	db "example/employee/server/db/sqlc"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type CreateJobRequest struct {
+	JobTitle  string        `form:"job_title" json:"job_title" binding:"required"`
+	MinSalary sql.NullInt64 `form:"min_salary" json:"min_salary" binding:"required"`
+	MaxSalary sql.NullInt64 `from:"max_salary" json:"max_salary" binding:"required"`
+}
+
+func (server *Server) createJob(ctx *gin.Context) {
+	var req CreateJobRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	arg := db.CreateJobParams{
+		JobTitle:  req.JobTitle,
+		MinSalary: req.MinSalary,
+		MaxSalary: req.MaxSalary,
+	}
+
+	job, err := server.store.CreateJob(ctx, arg)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, job)
+}
+
+type GetJobRequest struct {
+	JobID int64 `uri:"id" binding:"required,min=1"`
+}
+
+func (server *Server) getJob(ctx *gin.Context) {
+	var req GetJobRequest
+	if err := ctx.ShouldBindUri(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	job, err := server.store.GetJob(ctx, req.JobID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			ctx.JSON(http.StatusNotFound, errorResponse(err))
+			return
+		}
+
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, job)
+}
+
+type ListJobsRequest struct {
+	PageID   int32 `form:"page_id" binding:"required,min=1"`
+	PageSize int32 `form:"page_size" binding:"required,min=5,max=10"`
+}
+
+func (server *Server) listJobs(ctx *gin.Context) {
+	var req ListJobsRequest
+	if err := ctx.ShouldBindQuery(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	arg := db.ListJobsParams{
+		Limit:  req.PageSize,
+		Offset: (req.PageID - 1) * req.PageSize,
+	}
+
+	jobs, err := server.store.ListJobs(ctx, arg)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, jobs)
+}
+
+type UpdateJobRequest struct {
+	JobID     int64         `uri:"id" binding:"required,min=1"`
+	JobTitle  string        `form:"job_title" json:"job_title" binding:"required"`
+	MinSalary sql.NullInt64 `form:"min_salary" json:"min_salary" binding:"required"`
+	MaxSalary sql.NullInt64 `from:"max_salary" json:"max_salary" binding:"required"`
+}
+
+func (server *Server) updateJob(ctx *gin.Context) {
+	var req UpdateJobRequest
+	if errInUri := ctx.ShouldBindUri(&req); errInUri != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(errInUri))
+		return
+	}
+
+	if errInJson := ctx.ShouldBindJSON(&req); errInJson != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(errInJson))
+		return
+	}
+
+	arg := db.UpdateJobParams{
+		JobID:     req.JobID,
+		JobTitle:  req.JobTitle,
+		MinSalary: req.MinSalary,
+		MaxSalary: req.MaxSalary,
+	}
+
+	job, err := server.store.UpdateJob(ctx, arg)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, job)
+}
+
+type DeleteJobRequest struct {
+	JobID int64 `uri:"id" binding:"required,min=1"`
+}
+
+func (server *Server) deleteJob(ctx *gin.Context) {
+	var req DeleteJobRequest
+	if err := ctx.ShouldBindUri(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	err := server.store.DeleteJob(ctx, req.JobID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			ctx.JSON(http.StatusNotFound, errorResponse(err))
+			return
+		}
+
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, "success")
+}

--- a/api/job.go
+++ b/api/job.go
@@ -133,15 +133,21 @@ func (server *Server) deleteJob(ctx *gin.Context) {
 		return
 	}
 
-	err := server.store.DeleteJob(ctx, req.JobID)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			ctx.JSON(http.StatusNotFound, errorResponse(err))
+	_, err1 := server.store.GetJob(ctx, req.JobID)
+	if err1 != nil {
+		if err1 == sql.ErrNoRows {
+			ctx.JSON(http.StatusNotFound, errorResponse(err1))
 			return
 		}
 
-		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err1))
 		return
+	}
+
+	err2 := server.store.DeleteJob(ctx, req.JobID)
+
+	if err2 != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err2))
 	}
 
 	ctx.JSON(http.StatusOK, "success")

--- a/api/job_test.go
+++ b/api/job_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	mockdb "example/employee/server/db/mock"
+	db "example/employee/server/db/sqlc"
+	"example/employee/server/util"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetJob(t *testing.T) {
+	job := randomJob()
+
+	testCases := []struct {
+		name          string
+		jobID         int64
+		buildStub     func(store *mockdb.MockStore)
+		checkResponse func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			name:  "OK",
+			jobID: job.JobID,
+			buildStub: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					GetJob(gomock.Any(), gomock.Eq(job.JobID)).
+					Times(1).
+					Return(job, nil)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+				requireBodyMatchJob(t, recorder.Body, job)
+			},
+		},
+		{
+			name:  "NotFound",
+			jobID: job.JobID,
+			buildStub: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					GetJob(gomock.Any(), gomock.Eq(job.JobID)).
+					Times(1).
+					Return(db.Job{}, sql.ErrNoRows)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusNotFound, recorder.Code)
+			},
+		},
+		{
+			name:  "InternalError",
+			jobID: job.JobID,
+			buildStub: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					GetJob(gomock.Any(), gomock.Eq(job.JobID)).
+					Times(1).
+					Return(db.Job{}, sql.ErrConnDone)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusInternalServerError, recorder.Code)
+			},
+		},
+		{
+			name:  "BadRequest-Invalid ID",
+			jobID: 0,
+			buildStub: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					GetJob(gomock.Any(), gomock.Any()).
+					Times(0)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+	}
+
+	for i := range testCases {
+		currentTest := testCases[i]
+
+		t.Run(currentTest.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			store := mockdb.NewMockStore(ctrl)
+			currentTest.buildStub(store)
+
+			server := NewServer(store)
+			recorder := httptest.NewRecorder()
+
+			url := fmt.Sprintf("/jobs/%d", currentTest.jobID)
+			request, err := http.NewRequest(http.MethodGet, url, nil)
+			require.NoError(t, err)
+
+			server.router.ServeHTTP(recorder, request)
+			currentTest.checkResponse(t, recorder)
+		})
+
+	}
+
+}
+
+func randomJob() db.Job {
+	return db.Job{
+		JobID:     util.RandomInt64(1, 1000),
+		JobTitle:  util.RandomJobTitle(),
+		MinSalary: sql.NullInt64{util.RandomMinSalary(), true},
+		MaxSalary: sql.NullInt64{util.RandomMaxSalary(), true},
+	}
+}
+
+func requireBodyMatchJob(t *testing.T, responseBody *bytes.Buffer, job db.Job) {
+	data, err := ioutil.ReadAll(responseBody)
+	require.NoError(t, err)
+
+	var gotJob db.Job
+	err = json.Unmarshal(data, &gotJob)
+	require.NoError(t, err)
+	require.Equal(t, job, gotJob)
+}

--- a/api/server.go
+++ b/api/server.go
@@ -17,6 +17,13 @@ func NewServer(store db.Store) *Server {
 
 	router.POST("/departments", server.createDepartment)
 
+	// router for job
+	router.POST("/jobs", server.createJob)
+	router.GET("/jobs/:id", server.getJob)
+	router.GET("/jobs", server.listJobs)
+	router.PUT("/jobs/:id", server.updateJob)
+	router.DELETE("/jobs/:id", server.deleteJob)
+
 	server.router = router
 	return server
 }

--- a/db/sqlc/department.sql.go
+++ b/db/sqlc/department.sql.go
@@ -65,7 +65,7 @@ func (q *Queries) ListDepartments(ctx context.Context, arg ListDepartmentsParams
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Department
+	items := []Department{}
 	for rows.Next() {
 		var i Department
 		if err := rows.Scan(&i.DepartmentID, &i.DepartmentName); err != nil {

--- a/db/sqlc/employee.sql.go
+++ b/db/sqlc/employee.sql.go
@@ -119,7 +119,7 @@ func (q *Queries) ListEmployees(ctx context.Context, arg ListEmployeesParams) ([
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Employee
+	items := []Employee{}
 	for rows.Next() {
 		var i Employee
 		if err := rows.Scan(

--- a/db/sqlc/job.sql.go
+++ b/db/sqlc/job.sql.go
@@ -84,7 +84,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Job
+	items := []Job{}
 	for rows.Next() {
 		var i Job
 		if err := rows.Scan(

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -9,3 +9,4 @@ packages:
     emit_prepared_queries: false
     emit_interface: true
     emit_exact_table_names: false
+    emit_empty_slices: true


### PR DESCRIPTION
Trello ticket: [BK3738](https://trello.com/c/LCHJCO4h/62-bk3738-3-create-job-endpoints)

Result:
```
ok  	example/employee/server/api	0.540s	coverage: 95.1% of statements
```

Unit tests:
- [x] TestCreateJob
- [x] TestGetJob
- [x] TestListJobs
- [x] TestUpdateJob
- [x] TestDeleteJob

~Current issues:~

- [x] `GET /job` will return `null` instead of `[]` when there is no result (i.e. `page_id = 100` which is out of range.)
- [x] `DELETE /job/:id` will always return `success` even if the `id` is **not exist** in DB

