### PR TITLE
Feature/em 2742 activate user

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"database/sql"
+	"errors"
+	db "example/employee/server/db/sqlc"
+	"example/employee/server/util"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type ActivateUserRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+type ActivateUserResponse struct {
+	Email     string        `json:"email"`
+	Status    db.UserStatus `json:"status"`
+	CreatedAt time.Time     `json:"created_at"`
+	UpdatedAt time.Time     `json:"updated_at"`
+}
+
+func (server *Server) activateUser(ctx *gin.Context) {
+	var req ActivateUserRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	user, err := server.store.GetUser(ctx, req.Email)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			ctx.JSON(http.StatusNotFound, errorResponse(err))
+			return
+		}
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	if user.Status != db.UserStatusPending {
+		err := errors.New("Only pending user can be activated")
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	hashedPassword, err := util.HashPassword(req.Password)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	arg := db.ActivateUserParams{
+		HashedPassword: hashedPassword,
+		Email:          req.Email,
+	}
+	err = server.store.ActivateUser(ctx, arg)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse((err)))
+		return
+	}
+
+	user, err = server.store.GetUser(ctx, req.Email)
+	resp := ActivateUserResponse{
+		Email:     user.Email,
+		Status:    user.Status,
+		CreatedAt: user.CreatedAt,
+		UpdatedAt: user.UpdatedAt,
+	}
+
+	ctx.JSON(http.StatusOK, resp)
+}

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	mockdb "example/employee/server/db/mock"
+	db "example/employee/server/db/sqlc"
+	"example/employee/server/util"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func randomePendingUser(t *testing.T) db.User {
+	hashedPassword, err := util.HashPassword(util.RandomString(6))
+	require.NoError(t, err)
+	return db.User{
+		Email:          util.RandomEmail(),
+		HashedPassword: hashedPassword,
+		Status:         db.UserStatusPending,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+}
+func TestActivateUserAPI(t *testing.T) {
+	pendingUser := randomePendingUser(t)
+
+	activatedUser := pendingUser
+	activatedUser.Status = db.UserStatusActivated
+	activatedUser.UpdatedAt = time.Now().Add(time.Minute)
+
+	newPassword := "newPassword"
+	testCases := []struct {
+		name                string
+		activateUserReuqest ActivateUserRequest
+		buildStubs          func(store *mockdb.MockStore)
+		checkResponse       func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			name: "OK",
+			activateUserReuqest: ActivateUserRequest{
+				Email:    pendingUser.Email,
+				Password: newPassword,
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(pendingUser.Email)).
+					Times(1).
+					Return(pendingUser, nil)
+				store.EXPECT().ActivateUser(gomock.Any(), gomock.Any()).Times(1)
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(pendingUser.Email)).
+					Times(1).
+					Return(activatedUser, nil)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, recorder.Code)
+				requiredBodyMatchActiveUser(t, recorder.Body, pendingUser)
+			},
+		},
+		{
+			name: "Request non-pending user should got 400",
+			activateUserReuqest: ActivateUserRequest{
+				Email:    activatedUser.Email,
+				Password: newPassword,
+			},
+			buildStubs: func(store *mockdb.MockStore) {
+				store.EXPECT().
+					GetUser(gomock.Any(), gomock.Eq(activatedUser.Email)).
+					Times(1).
+					Return(activatedUser, nil)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusBadRequest, recorder.Code)
+			},
+		},
+	}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+
+			store := mockdb.NewMockStore(controller)
+			tc.buildStubs(store)
+
+			server := NewServer(store)
+			recorder := httptest.NewRecorder()
+
+			jsonBytes, err := json.Marshal(tc.activateUserReuqest)
+			url := fmt.Sprintf("/auth/activate")
+			request, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(jsonBytes))
+
+			require.NoError(t, err)
+			server.router.ServeHTTP(recorder, request)
+			tc.checkResponse(t, recorder)
+		})
+	}
+
+}
+
+func requiredBodyMatchActiveUser(t *testing.T, body *bytes.Buffer, user db.User) {
+	data, err := ioutil.ReadAll(body)
+	require.NoError(t, err)
+	var resp ActivateUserResponse
+	err = json.Unmarshal(data, &resp)
+	require.NoError(t, err)
+	require.Equal(t, user.Email, resp.Email)
+	require.Equal(t, db.UserStatusActivated, resp.Status)
+	require.True(t, resp.UpdatedAt.After(user.UpdatedAt))
+}

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"os"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestMain(m *testing.M) {
-	// gin.SetMode(gin.TestMode)
+	gin.SetMode(gin.TestMode)
 	os.Exit(m.Run())
 }

--- a/api/server.go
+++ b/api/server.go
@@ -12,15 +12,23 @@ type Server struct {
 }
 
 func NewServer(store db.Store) *Server {
-	server := &Server{store: store}
+	server := &Server{
+		store: store,
+	}
+
+	server.setupRouter()
+	return server
+}
+
+func (server *Server) setupRouter() {
 	router := gin.Default()
 
 	router.POST("/departments", server.createDepartment)
 
-	server.router = router
-	return server
-}
+	router.POST("/auth/activate", server.activateUser)
 
+	server.router = router
+}
 func (server *Server) Start(address string) error {
 	return server.router.Run(address)
 }

--- a/db/mock/store.go
+++ b/db/mock/store.go
@@ -35,6 +35,20 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
+// ActivateUser mocks base method.
+func (m *MockStore) ActivateUser(arg0 context.Context, arg1 db.ActivateUserParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ActivateUser", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ActivateUser indicates an expected call of ActivateUser.
+func (mr *MockStoreMockRecorder) ActivateUser(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivateUser", reflect.TypeOf((*MockStore)(nil).ActivateUser), arg0, arg1)
+}
+
 // CreateDepartment mocks base method.
 func (m *MockStore) CreateDepartment(arg0 context.Context, arg1 string) (db.Department, error) {
 	m.ctrl.T.Helper()

--- a/db/query/user.sql
+++ b/db/query/user.sql
@@ -12,3 +12,8 @@ RETURNING *;
 -- name: GetUser :one
 SELECT * FROM users
 WHERE email = $1 LIMIT 1;
+
+-- name: ActivateUser :exec
+UPDATE users
+SET hashed_password = $1, status = 'activated', updated_at = now()
+WHERE email = $2;

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Querier interface {
+	ActivateUser(ctx context.Context, arg ActivateUserParams) error
 	CreateDepartment(ctx context.Context, departmentName string) (Department, error)
 	CreateEmployee(ctx context.Context, arg CreateEmployeeParams) (Employee, error)
 	CreateJob(ctx context.Context, arg CreateJobParams) (Job, error)

--- a/db/sqlc/user.sql.go
+++ b/db/sqlc/user.sql.go
@@ -9,6 +9,22 @@ import (
 	"context"
 )
 
+const activateUser = `-- name: ActivateUser :exec
+UPDATE users
+SET hashed_password = $1, status = 'activated', updated_at = now()
+WHERE email = $2
+`
+
+type ActivateUserParams struct {
+	HashedPassword string `json:"hashed_password"`
+	Email          string `json:"email"`
+}
+
+func (q *Queries) ActivateUser(ctx context.Context, arg ActivateUserParams) error {
+	_, err := q.db.ExecContext(ctx, activateUser, arg.HashedPassword, arg.Email)
+	return err
+}
+
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (
 email,


### PR DESCRIPTION
The user would be created when [POST] /employees is called.
[Post] /auth/activate used to reset the password for the user when first login the system. You may cheat it as registration api.